### PR TITLE
Added inserts from megatable to normalized tables

### DIFF
--- a/MegaToMainInserts.sql
+++ b/MegaToMainInserts.sql
@@ -1,0 +1,31 @@
+# This file inserts all relevant data from the megatable into our normalized tables
+
+USE NCAA;
+
+INSERT INTO games
+	SELECT DISTINCT game_id, season, neutral_site, scheduled_date, gametime
+    FROM megatable;
+
+INSERT INTO tournament_games
+	SELECT DISTINCT game_id, tournament, tournament_type, tournament_round, tournament_game
+    FROM megatable
+    WHERE tournament IS NOT NULL;
+    
+INSERT INTO teams
+	SELECT DISTINCT team_id, team_market, team_name, team_alias, conf_name, conf_alias,
+					division_name, division_alias, league_name
+    FROM megatable;
+    
+INSERT INTO players
+	SELECT player_id, last_name, first_name, full_name, abbr_name, birthplace, 
+			birthplace_city, birthplace_state, birthplace_country, team_id
+	FROM megatable
+    GROUP BY player_id;
+
+INSERT INTO player_stats
+	SELECT player_id, status, jersey_number, height, weight, class, game_id, home_team, active,
+			played, starter, minutes, minutes_int64, position, primary_position,field_goals_made, field_goals_att,
+			three_points_made, three_points_att, two_points_made, two_points_att, blocked_att, free_throws_made,
+			free_throws_att, offensive_rebounds, defensive_rebounds, rebounds, assists, turnovers, steals,
+			blocks, personal_fouls, tech_fouls, flagrant_fouls, points
+	FROM megatable;

--- a/NCAAMainTables.sql
+++ b/NCAAMainTables.sql
@@ -59,15 +59,10 @@ CREATE TABLE players (
     first_name VARCHAR(50),
     full_name VARCHAR(100),
     abbr_name VARCHAR(75),
-    status VARCHAR(10),
-    jersey_number TINYINT UNSIGNED,
-    height TINYINT UNSIGNED,
-    weight TINYINT UNSIGNED,
     birthplace VARCHAR(255),
     birthplace_city VARCHAR(40),
     birthplace_state VARCHAR(40),
     birthplace_country VARCHAR(40),
-    class VARCHAR(40),
     team_id VARCHAR(255),
     PRIMARY KEY (player_id),
     CONSTRAINT fk_teamid FOREIGN KEY (team_id)
@@ -81,6 +76,11 @@ CREATE TABLE players (
 DROP TABLE IF EXISTS player_stats;
 CREATE TABLE player_stats (
 	player_id VARCHAR(255),
+    status VARCHAR(10),
+    jersey_number TINYINT UNSIGNED,
+    height TINYINT UNSIGNED,
+    weight TINYINT UNSIGNED,
+    class VARCHAR(40),
     game_id VARCHAR(255),
     home_team VARCHAR(20),
     active VARCHAR(20),


### PR DESCRIPTION
All the data should now be migrated from the megatable to the normalized tables. I ran into a couple problems that required moving things around. Some of the data for the players wasn't consistent so I had to squash some of the data so there was some loss. To use an example, one player had his name as "[first_name last_name]" in one spot and "[first_name last_name] Jr." in another, but he had the same player_id, so I grouped by player_id and lost the record of his name as "[first_name last_name]". Not a big deal at all and as long as he has one player_id it's the same person regardless. Also I moved status, jersey_number, class, height, and weight to player_stats as those numbers were liable to change for the same player in different games. Other than that, all the data went smoothly.